### PR TITLE
ces2018/doma: Change access protocol to ssh for EPAM

### DIFF
--- a/prod_ces2018/doma.xml
+++ b/prod_ces2018/doma.xml
@@ -5,7 +5,7 @@
         review="https://android-review.googlesource.com/" />
 
   <remote  name="epam"
-        fetch="git.epam.com:epmd-aepr/"
+        fetch="ssh://git@git.epam.com/epmd-aepr/"
         revision="master" />
 
   <default revision="refs/tags/android-8.0.0_r4"


### PR DESCRIPTION
Repositories from internal network must be accessed via
ssh protocol, not git.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>