### PR TITLE
Switch doma manifest to Android BSP v1.2.0

### DIFF
--- a/prod_ces2018/doma.xml
+++ b/prod_ces2018/doma.xml
@@ -6,15 +6,15 @@
 
   <remote  name="epam"
         fetch="ssh://git@gitpct.epam.com/epmd-aepr/"
-        revision="master" />
+        revision="android-bsp-v1.2.0" />
 
   <default revision="refs/tags/android-8.0.0_r4"
            remote="aosp"
            sync-j="4" />
 
   <!-- REL BSP projects -->
-  <project path="device/renesas/salvator" name="android_device_renesas_salvator" group="rel" remote="epam" revision="android-bsp-v0.2.2-ces2018" />
-  <project path="device/renesas/kernel" name="android_device_renesas_kernel" group="rel" remote="epam" revision="android-bsp-v0.2.2-ces2018" />
+  <project path="device/renesas/salvator" name="android_device_renesas_salvator" group="rel" remote="epam" revision="android-bsp-v1.2.0-ces2018" />
+  <project path="device/renesas/kernel" name="android_device_renesas_kernel" group="rel" remote="epam" revision="android-bsp-v1.2.0-ces2018" />
   <project path="device/renesas/bootloaders/u-boot" name="android_device_renesas_bootloaders_u-boot" group="rel" remote="epam" />
   <project path="device/renesas/bootloaders/ipl" name="android_device_renesas_bootloaders_ipl" group="rel" remote="epam" />
   <project path="device/renesas/bootloaders/optee" name="android_device_renesas_bootloaders_optee" group="rel" remote="epam" />

--- a/prod_ces2018/doma.xml
+++ b/prod_ces2018/doma.xml
@@ -32,6 +32,8 @@
   <project path="hardware/renesas/qos" name="android_hardware_renesas_qos" group="rel" remote="epam" />
   <project path="hardware/renesas/qos_km" name="android_hardware_renesas_qos_km" group="rel" remote="epam" />
   <project path="prebuilts/gcc/linux-x86/aarch64/aarch64-linux-gnu-5.2" name="android_prebuilds_gcc_linuxx86_aarch64" group="rel" remote="epam" />
+  <project path="vendor/imagination/clang" name="android_vendor_imagination_clang" group="rel" remote="epam" />
+  <project path="vendor/imagination/llvm" name="android_vendor_imagination_llvm" group="rel" remote="epam" />
 
   <!-- AOSP projects with changes -->
   <project path="external/avb" name="android_external_avb" groups="pdk,rel" remote="epam" />


### PR DESCRIPTION
- Set default branch for epam projects to android-bsp-v1.2.0
- Add LLVM and CLANG projects related to DDK 1.9
- Switch device/renesas/salvator, device/renesas/kernel
to android-bsp-v1.2.0-ces2018 branch

Signed-off-by: Andrii Chepurnyi <andrii_chepurnyi@epam.com>