### PR TITLE
Split manifest files

### DIFF
--- a/prod_devel/domd.xml
+++ b/prod_devel/domd.xml
@@ -4,7 +4,6 @@
     <remote name="yoctoproject" fetch="git://git.yoctoproject.org" />
     <remote name="openembedded" fetch="git://git.openembedded.org" />
     <remote name="linaro" fetch="git://git.linaro.org" />
-    <remote name="epam" fetch="ssh://git@gitpct.epam.com" />
 
     <default remote="github" sync-j="10" sync-c="true" />
 
@@ -14,5 +13,4 @@
     <project remote="openembedded" name="meta-openembedded" path="meta-openembedded" upstream="rocko" revision="dacfa2b1920e285531bec55cd2f08743390aaf57" />
     <project remote="linaro" name="openembedded/meta-linaro" path="meta-linaro" upstream="rocko" revision="75dfb67bbb14a70cd47afda9726e2e1c76731885" />
     <project remote="yoctoproject" name="meta-selinux" path="meta-selinux" upstream="morty" revision="morty" />
-    <project remote="epam" name="epmd-aepr/img-proprietary" path="proprietary" upstream="master" revision="master" />
 </manifest>

--- a/prod_devel/domu.xml
+++ b/prod_devel/domu.xml
@@ -4,7 +4,6 @@
     <remote name="yoctoproject" fetch="git://git.yoctoproject.org" />
     <remote name="openembedded" fetch="git://git.openembedded.org" />
     <remote name="linaro" fetch="git://git.linaro.org" />
-    <remote name="epam" fetch="ssh://git@gitpct.epam.com" />
 
     <default remote="github" sync-j="10" sync-c="true" />
 
@@ -13,5 +12,4 @@
     <project remote="openembedded" name="meta-openembedded" path="meta-openembedded" upstream="rocko" revision="dacfa2b1920e285531bec55cd2f08743390aaf57" />
     <project remote="linaro" name="openembedded/meta-linaro" path="meta-linaro" upstream="rocko" revision="75dfb67bbb14a70cd47afda9726e2e1c76731885" />
     <project remote="yoctoproject" name="meta-selinux" path="meta-selinux" upstream="morty" revision="morty" />
-    <project remote="epam" name="epmd-aepr/img-proprietary" path="proprietary" upstream="master" revision="master" />
 </manifest>

--- a/prod_devel_src/domd.xml
+++ b/prod_devel_src/domd.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+    <include name="prod_devel/domd.xml"/>
+
+    <remote name="epam" fetch="ssh://git@gitpct.epam.com" />
+    <project remote="epam" name="epmd-aepr/img-proprietary" path="proprietary" upstream="master" revision="master" />
+</manifest>

--- a/prod_devel_src/domu.xml
+++ b/prod_devel_src/domu.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+    <include name="prod_devel/domu.xml"/>
+
+    <remote name="epam" fetch="ssh://git@gitpct.epam.com" />
+    <project remote="epam" name="epmd-aepr/img-proprietary" path="proprietary" upstream="master" revision="master" />
+</manifest>
+


### PR DESCRIPTION
Add separate part of manifest files with closed repository.
It is needed to build prod-devel with proprietary
graphic from sources.

Signed-off-by: Iurii Artemenko <iurii_artemenko@epam.com>