### PR TITLE
Make reconstruction possible for the rest of products

### DIFF
--- a/prod_aos/domd.xml
+++ b/prod_aos/domd.xml
@@ -5,6 +5,7 @@
   <remote fetch="git://git.openembedded.org/" name="openembedded"/>
   <remote fetch="git://code.qt.io/" name="qt.io"/>
   <remote fetch="git://git.yoctoproject.org/" name="yocto"/>
+  <remote fetch="ssh://git@gitpct.epam.com" name="epam"/>
   
   <default remote="agl" revision="refs/tags/flounder/6.0.2" sync-j="4"/>
   
@@ -32,4 +33,6 @@
   <project name="meta-virtualization" remote="yocto" revision="bd77388f31929f38e7d4cc9c711f0f83f563007e" upstream="rocko"/>
   <project name="phongt/meta-sdl" path="meta-sdl" remote="github" revision="60c9fe8a4a9c6ca95f222685f8d6248f16236f2a" upstream="release/4.4.0"/>
   <project name="poky" remote="yocto" revision="05711ba18587aaaf4a9c465a1dd4537f27ceda93" upstream="rocko"/>
+  <project remote="github" name="madisongh/meta-golang" path="meta-golang" upstream="rocko" revision="rocko" />
+  <project remote="epam" name="epmd-aepr/meta-aos" path="meta-aos" upstream="master" revision="master" />
 </manifest>

--- a/prod_aos/domf.xml
+++ b/prod_aos/domf.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+    <remote name="github" fetch="git://github.com" />
+    <remote name="yoctoproject" fetch="git://git.yoctoproject.org" />
+    <remote name="openembedded" fetch="git://git.openembedded.org" />
+    <remote name="linaro" fetch="git://git.linaro.org" />
+    <remote name="epam" fetch="ssh://git@gitpct.epam.com" />
+
+    <default remote="github" sync-j="10" sync-c="true" />
+
+    <project remote="yoctoproject" name="meta-virtualization" path="meta-virtualization" upstream="rocko" revision="rocko" />
+    <project remote="yoctoproject" name="poky" path="poky" upstream="rocko" revision="342fbd6a3e57021c8e28b124b3adb241936f3d9d" />
+    <project remote="openembedded" name="meta-openembedded" path="meta-openembedded" upstream="rocko" revision="eae996301d9c097bcbeb8046f08041dc82bb62f8" />
+    <project name="madisongh/meta-golang" path="meta-golang" upstream="rocko" revision="rocko" />
+    <project remote="epam" name="epmd-aepr/meta-aos" path="meta-aos" upstream="master" revision="master" />
+</manifest>

--- a/prod_ces2019/domd.xml
+++ b/prod_ces2019/domd.xml
@@ -5,7 +5,8 @@
   <remote fetch="git://git.openembedded.org/" name="openembedded"/>
   <remote fetch="git://code.qt.io/" name="qt.io"/>
   <remote fetch="git://git.yoctoproject.org/" name="yocto"/>
-  
+  <remote fetch="ssh://git@gitpct.epam.com" name="epam"/>
+
   <default remote="agl" revision="refs/tags/flounder/6.0.2" sync-j="4"/>
   
   <project name="01org/meta-security-isafw" path="meta-security-isafw" remote="github" revision="489abdc65cefb566d696c8b218aa0b9b99a350ae" upstream="master"/>
@@ -32,4 +33,5 @@
   <project name="meta-virtualization" remote="yocto" revision="bd77388f31929f38e7d4cc9c711f0f83f563007e" upstream="rocko"/>
   <project name="phongt/meta-sdl" path="meta-sdl" remote="github" revision="60c9fe8a4a9c6ca95f222685f8d6248f16236f2a" upstream="release/4.4.0"/>
   <project name="poky" remote="yocto" revision="05711ba18587aaaf4a9c465a1dd4537f27ceda93" upstream="rocko"/>
+  <project remote="epam" name="epmd-aepr/img-proprietary" path="proprietary" upstream="master" revision="master" />
 </manifest>

--- a/prod_gen3_test/domd.xml
+++ b/prod_gen3_test/domd.xml
@@ -13,4 +13,5 @@
     <project remote="openembedded" name="meta-openembedded" path="meta-openembedded" upstream="rocko" revision="dacfa2b1920e285531bec55cd2f08743390aaf57" />
     <project remote="linaro" name="openembedded/meta-linaro" path="meta-linaro" upstream="rocko" revision="75dfb67bbb14a70cd47afda9726e2e1c76731885" />
     <project remote="yoctoproject" name="meta-selinux" path="meta-selinux" upstream="morty" revision="morty" />
+    <project name="kraj/meta-clang" path="meta-clang" upstream="rocko" revision="rocko" />
 </manifest>

--- a/prod_gen3_test/domu.xml
+++ b/prod_gen3_test/domu.xml
@@ -12,4 +12,5 @@
     <project remote="openembedded" name="meta-openembedded" path="meta-openembedded" upstream="rocko" revision="dacfa2b1920e285531bec55cd2f08743390aaf57" />
     <project remote="linaro" name="openembedded/meta-linaro" path="meta-linaro" upstream="rocko" revision="75dfb67bbb14a70cd47afda9726e2e1c76731885" />
     <project remote="yoctoproject" name="meta-selinux" path="meta-selinux" upstream="morty" revision="morty" />
+    <project name="kraj/meta-clang" path="meta-clang" upstream="rocko" revision="rocko" />
 </manifest>


### PR DESCRIPTION
Move open coded additional meta layers from
recipes into manifests, so build reconstruction can happen.

Signed-off-by: Iurii Artemenko <iurii_artemenko@epam.com>