### PR TITLE
Add a copy of AGL manifest file as domd.xml

### DIFF
--- a/prod_aos/domd.xml
+++ b/prod_aos/domd.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+  <remote fetch="https://gerrit.automotivelinux.org/gerrit/" name="agl" pushurl="ssh://gerrit.automotivelinux.org:29418" review="https://gerrit.automotivelinux.org/gerrit/"/>
+  <remote fetch="https://github.com/" name="github"/>
+  <remote fetch="git://git.openembedded.org/" name="openembedded"/>
+  <remote fetch="git://code.qt.io/" name="qt.io"/>
+  <remote fetch="git://git.yoctoproject.org/" name="yocto"/>
+  
+  <default remote="agl" revision="refs/tags/flounder/6.0.2" sync-j="4"/>
+  
+  <project name="01org/meta-security-isafw" path="meta-security-isafw" remote="github" revision="489abdc65cefb566d696c8b218aa0b9b99a350ae" upstream="master"/>
+  <project name="AGL/meta-agl" path="meta-agl"/>
+  <project name="AGL/meta-agl-demo" path="meta-agl-demo"/>
+  <project name="AGL/meta-agl-devel" path="meta-agl-devel"/>
+  <project name="AGL/meta-agl-extra" path="meta-agl-extra"/>
+  <project name="AGL/meta-renesas-rcar-gen3" path="meta-renesas-rcar-gen3"/>
+  <project name="CogentEmbedded/meta-rcar" path="meta-rcar" remote="github" revision="a0551596548ef3a4c9132161f3d9c4ae538d6fdc" upstream="v3.7.0"/>
+  <project name="advancedtelematic/meta-updater" path="meta-updater" remote="github" revision="ff555e8690eb47177ade42dc6912ae17a759cc45" upstream="rocko"/>
+  <project name="advancedtelematic/meta-updater-qemux86-64" path="meta-updater-qemux86-64" remote="github" revision="697632ddd98ed7ae3dbd0bd84abb04079767bc56" upstream="rocko"/>
+  <project name="boundarydevices/meta-boundary" path="meta-boundary" remote="github" revision="f96f41b2e5beda2b51acb702d082568898b36a68" upstream="rocko"/>
+  <project name="kraj/meta-altera" path="meta-altera" remote="github" revision="14e08a419cb9d4017f40360c14fcc3c2c1ce8e42" upstream="rocko"/>
+  <project name="meta-freescale" remote="yocto" revision="a4158e3425a79720ddc4c02e76251d567bdceb51" upstream="rocko"/>
+  <project name="meta-gplv2" remote="yocto" revision="f875c60ecd6f30793b80a431a2423c4b98e51548" upstream="rocko"/>
+  <project name="meta-intel" remote="yocto" revision="718bb384942675437c081f6795da7f421da1fee6" upstream="rocko"/>
+  <project name="meta-oic" remote="yocto" revision="6e831e4bcdfa6ab8c26eb4fca4bdc98faf028818" upstream="1.2.1"/>
+  <project name="meta-openembedded" remote="openembedded" revision="eae996301d9c097bcbeb8046f08041dc82bb62f8" upstream="rocko"/>
+  <project name="meta-qcom" remote="yocto" revision="955ce2625de5d8c7fe313bd4630c8a290e4b96f8" upstream="rocko"/>
+  <project name="meta-qt5/meta-qt5" path="meta-qt5" remote="github" revision="682ad61c071a9710e9f9d8a32ab1b5f3c14953d1" upstream="rocko"/>
+  <project name="meta-raspberrypi" remote="yocto" revision="8e4c537d84fdde8e3b4642d0dda2c0f4af76d52f" upstream="rocko"/>
+  <project name="meta-security" remote="yocto" revision="8f6969a775fa6afbf553e72ba83e71197780b2d8" upstream="master"/>
+  <project name="meta-ti" remote="yocto" revision="ed83a43c6a76875ee5f0388b3b60a28f2a373a10" upstream="rocko"/>
+  <project name="meta-virtualization" remote="yocto" revision="bd77388f31929f38e7d4cc9c711f0f83f563007e" upstream="rocko"/>
+  <project name="phongt/meta-sdl" path="meta-sdl" remote="github" revision="60c9fe8a4a9c6ca95f222685f8d6248f16236f2a" upstream="release/4.4.0"/>
+  <project name="poky" remote="yocto" revision="05711ba18587aaaf4a9c465a1dd4537f27ceda93" upstream="rocko"/>
+</manifest>

--- a/prod_ces2019/domd.xml
+++ b/prod_ces2019/domd.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+  <remote fetch="https://gerrit.automotivelinux.org/gerrit/" name="agl" pushurl="ssh://gerrit.automotivelinux.org:29418" review="https://gerrit.automotivelinux.org/gerrit/"/>
+  <remote fetch="https://github.com/" name="github"/>
+  <remote fetch="git://git.openembedded.org/" name="openembedded"/>
+  <remote fetch="git://code.qt.io/" name="qt.io"/>
+  <remote fetch="git://git.yoctoproject.org/" name="yocto"/>
+  
+  <default remote="agl" revision="refs/tags/flounder/6.0.2" sync-j="4"/>
+  
+  <project name="01org/meta-security-isafw" path="meta-security-isafw" remote="github" revision="489abdc65cefb566d696c8b218aa0b9b99a350ae" upstream="master"/>
+  <project name="AGL/meta-agl" path="meta-agl"/>
+  <project name="AGL/meta-agl-demo" path="meta-agl-demo"/>
+  <project name="AGL/meta-agl-devel" path="meta-agl-devel"/>
+  <project name="AGL/meta-agl-extra" path="meta-agl-extra"/>
+  <project name="AGL/meta-renesas-rcar-gen3" path="meta-renesas-rcar-gen3"/>
+  <project name="CogentEmbedded/meta-rcar" path="meta-rcar" remote="github" revision="a0551596548ef3a4c9132161f3d9c4ae538d6fdc" upstream="v3.7.0"/>
+  <project name="advancedtelematic/meta-updater" path="meta-updater" remote="github" revision="ff555e8690eb47177ade42dc6912ae17a759cc45" upstream="rocko"/>
+  <project name="advancedtelematic/meta-updater-qemux86-64" path="meta-updater-qemux86-64" remote="github" revision="697632ddd98ed7ae3dbd0bd84abb04079767bc56" upstream="rocko"/>
+  <project name="boundarydevices/meta-boundary" path="meta-boundary" remote="github" revision="f96f41b2e5beda2b51acb702d082568898b36a68" upstream="rocko"/>
+  <project name="kraj/meta-altera" path="meta-altera" remote="github" revision="14e08a419cb9d4017f40360c14fcc3c2c1ce8e42" upstream="rocko"/>
+  <project name="meta-freescale" remote="yocto" revision="a4158e3425a79720ddc4c02e76251d567bdceb51" upstream="rocko"/>
+  <project name="meta-gplv2" remote="yocto" revision="f875c60ecd6f30793b80a431a2423c4b98e51548" upstream="rocko"/>
+  <project name="meta-intel" remote="yocto" revision="718bb384942675437c081f6795da7f421da1fee6" upstream="rocko"/>
+  <project name="meta-oic" remote="yocto" revision="6e831e4bcdfa6ab8c26eb4fca4bdc98faf028818" upstream="1.2.1"/>
+  <project name="meta-openembedded" remote="openembedded" revision="eae996301d9c097bcbeb8046f08041dc82bb62f8" upstream="rocko"/>
+  <project name="meta-qcom" remote="yocto" revision="955ce2625de5d8c7fe313bd4630c8a290e4b96f8" upstream="rocko"/>
+  <project name="meta-qt5/meta-qt5" path="meta-qt5" remote="github" revision="682ad61c071a9710e9f9d8a32ab1b5f3c14953d1" upstream="rocko"/>
+  <project name="meta-raspberrypi" remote="yocto" revision="8e4c537d84fdde8e3b4642d0dda2c0f4af76d52f" upstream="rocko"/>
+  <project name="meta-security" remote="yocto" revision="8f6969a775fa6afbf553e72ba83e71197780b2d8" upstream="master"/>
+  <project name="meta-ti" remote="yocto" revision="ed83a43c6a76875ee5f0388b3b60a28f2a373a10" upstream="rocko"/>
+  <project name="meta-virtualization" remote="yocto" revision="bd77388f31929f38e7d4cc9c711f0f83f563007e" upstream="rocko"/>
+  <project name="phongt/meta-sdl" path="meta-sdl" remote="github" revision="60c9fe8a4a9c6ca95f222685f8d6248f16236f2a" upstream="release/4.4.0"/>
+  <project name="poky" remote="yocto" revision="05711ba18587aaaf4a9c465a1dd4537f27ceda93" upstream="rocko"/>
+</manifest>


### PR DESCRIPTION
The manifest file is a copy of flounder_6.0.2.xml which is
storred on AGL repository and represents 6.0.2 version. Any other
updates are storred as a separate manifest files
i.e. flounder_6.0.3.xml. In order to use reconstruction
functionality we have to use it as a copy in our repository.

Signed-off-by: Iurii Artemenko <iurii_artemenko@epam.com>