### PR TITLE
domd/dom0/domu: Switch Prod-devel to Yocto Thud v2.6.2 (BSP v3.21.0)

### DIFF
--- a/prod_devel/dom0.xml
+++ b/prod_devel/dom0.xml
@@ -10,5 +10,5 @@
     <project remote="yoctoproject" name="meta-virtualization" path="meta-virtualization" upstream="thud" revision="9e8c0c96b443828a255e7d6ca6291598347672ac" />
     <project remote="yoctoproject" name="poky" path="poky" upstream="thud" revision="e7f0177ef3b6e06b8bc1722fca0241fef08a1530" />
     <project remote="openembedded" name="meta-openembedded" path="meta-openembedded" upstream="thud" revision="4cd3a39f22a2712bfa8fc657d09fe2c7765a4005" />
-    <project remote="linaro" name="openembedded/meta-linaro" path="meta-linaro" upstream="thud" revision="b30036d4ef7ce9fe746833fc54de6ac7b0e00638" />
+    <project remote="linaro" name="openembedded/meta-linaro" path="meta-linaro" upstream="thud" revision="0a94decea3bd2504590d1637eadff9d502c19ee2" />
 </manifest>

--- a/prod_devel/domd.xml
+++ b/prod_devel/domd.xml
@@ -7,13 +7,13 @@
 
     <default remote="github" sync-j="10" sync-c="true" />
 
-    <project name="renesas-rcar/meta-renesas" path="meta-renesas" upstream="thud-dev" revision="2a535519e1808bb3a43e88a6c5dcc0556fc7101d" />
+    <project name="renesas-rcar/meta-renesas" path="meta-renesas" upstream="thud-dev" revision="14fe2b63e6c580bd48446317a9430e6f035a5895" />
     <project remote="yoctoproject" name="meta-virtualization" path="meta-virtualization" upstream="thud" revision="9e8c0c96b443828a255e7d6ca6291598347672ac" />
     <project remote="yoctoproject" name="poky" path="poky" upstream="thud" revision="e7f0177ef3b6e06b8bc1722fca0241fef08a1530" />
     <project remote="openembedded" name="meta-openembedded" path="meta-openembedded" upstream="thud" revision="4cd3a39f22a2712bfa8fc657d09fe2c7765a4005" />
-    <project remote="linaro" name="openembedded/meta-linaro" path="meta-linaro" upstream="thud" revision="b30036d4ef7ce9fe746833fc54de6ac7b0e00638" />
+    <project remote="linaro" name="openembedded/meta-linaro" path="meta-linaro" upstream="thud" revision="0a94decea3bd2504590d1637eadff9d502c19ee2" />
     <project remote="yoctoproject" name="meta-selinux" path="meta-selinux" upstream="thud" revision="fb6192aa2c5df8e80c5e6d4fa5448d574332f68f" />
     <project name="kraj/meta-clang" path="meta-clang" upstream="thud" revision="7933fd19fe1df357df0532d3983c10d014e8d5f6" />
-    <project name="CogentEmbedded/meta-rcar" path="meta-rcar" revision="395dcd7cf5713672a59c9a3e1b75afaad5e446aa" upstream="v3.15.0" />
+    <project name="CogentEmbedded/meta-rcar" path="meta-rcar" revision="e9bf7907fcf1f3013705de10a37b7561f6660e3c" upstream="thud-v3.21.0" />
 
 </manifest>

--- a/prod_devel/domu.xml
+++ b/prod_devel/domu.xml
@@ -7,10 +7,10 @@
 
     <default remote="github" sync-j="10" sync-c="true" />
 
-    <project name="renesas-rcar/meta-renesas" path="meta-renesas" upstream="rocko" revision="8af0b7d6e445b532088a068dc012757001be3a1f" />
-    <project remote="yoctoproject" name="poky" path="poky" upstream="rocko" revision="7e7ee662f5dea4d090293045f7498093322802cc" />
-    <project remote="openembedded" name="meta-openembedded" path="meta-openembedded" upstream="rocko" revision="352531015014d1957d6444d114f4451e241c4d23" />
-    <project remote="linaro" name="openembedded/meta-linaro" path="meta-linaro" upstream="rocko" revision="75dfb67bbb14a70cd47afda9726e2e1c76731885" />
-    <project remote="yoctoproject" name="meta-selinux" path="meta-selinux" upstream="morty" revision="7351dfc00d7a56b8982582ba8e10ffa8940932cb" />
-    <project name="kraj/meta-clang" path="meta-clang" upstream="rocko" revision="533f882e77714a231a1cef985fd9bb7f56e44145" />
+    <project name="renesas-rcar/meta-renesas" path="meta-renesas" upstream="thud-dev" revision="14fe2b63e6c580bd48446317a9430e6f035a5895" />
+    <project remote="yoctoproject" name="poky" path="poky" upstream="thud" revision="e7f0177ef3b6e06b8bc1722fca0241fef08a1530" />
+    <project remote="openembedded" name="meta-openembedded" path="meta-openembedded" upstream="thud" revision="4cd3a39f22a2712bfa8fc657d09fe2c7765a4005" />
+    <project remote="linaro" name="openembedded/meta-linaro" path="meta-linaro" upstream="thud" revision="0a94decea3bd2504590d1637eadff9d502c19ee2" />
+    <project remote="yoctoproject" name="meta-selinux" path="meta-selinux" upstream="thud" revision="fb6192aa2c5df8e80c5e6d4fa5448d574332f68f" />
+    <project name="kraj/meta-clang" path="meta-clang" upstream="thud" revision="7933fd19fe1df357df0532d3983c10d014e8d5f6" />
 </manifest>


### PR DESCRIPTION
What we have had so far:
- Dom0 and DomD are based on Yocto Thud v2.6.0 (BSP v3.15.0).
- DomU is based on something outdated.

This patch switches all Linux based domains to Yocto Thud v2.6.2
(BSP v3.21.0) including "CogentEmbedded/meta-rcar" layer.

Signed-off-by: Oleksandr Tyshchenko <oleksandr_tyshchenko@epam.com>