### PR TITLE
devel: doma: Remove meta-java as not used

### DIFF
--- a/prod_devel/domu_android_host_tools.xml
+++ b/prod_devel/domu_android_host_tools.xml
@@ -6,6 +6,5 @@
     <default remote="yoctoproject" sync-j="10" sync-c="true" />
 
     <project remote="yoctoproject" name="poky" path="poky" upstream="pyro" revision="773e56f0e55760bea9cb79390441145f7953d1a7" />
-    <project remote="yoctoproject" name="meta-java" path="meta-java" upstream="pyro" revision="0c27b120aa508e4bb41394b8dd3645949a611128" />
     <project remote="openembedded" name="meta-openembedded" path="meta-openembedded" upstream="pyro" revision="9eaebc6e783f1394bb5444326cd05a976b3122e9" />
 </manifest>


### PR DESCRIPTION
Meta-java is not used anymore after
https://github.com/xen-troops/meta-xt-prod-devel/commit/29d653b01838c59a740cfbeb93cf2cf15af72455

Signed-off-by: Ruslan Shymkevych <ruslan_shymkevych@epam.com>