### PR TITLE
Move product manifests from xt-products.

### DIFF
--- a/prod_aos/prod-aos.xml
+++ b/prod_aos/prod-aos.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+    <remote name="github" fetch="git://github.com" />
+
+    <default remote="github" sync-j="10" sync-c="true" />
+
+    <project name="xen-troops/meta-xt-prod-aos" path="meta-xt-prod-aos" upstream="master" revision="master" />
+    <project name="xen-troops/meta-xt-images" path="meta-xt-images" upstream="master" revision="master" />
+    <project name="xen-troops/xt-distro" path="xt-distro" upstream="master" revision="master" />
+</manifest>

--- a/prod_ces2018/prod-ces2018.xml
+++ b/prod_ces2018/prod-ces2018.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+    <remote name="github" fetch="git://github.com" />
+
+    <default remote="github" sync-j="10" sync-c="true" />
+
+    <project name="xen-troops/meta-xt-prod-ces2018" path="meta-xt-prod-ces2018" upstream="master" revision="90cd5209900c417dd05095fb06b77e782c4473fa" />
+    <project name="xen-troops/meta-xt-images" path="meta-xt-images" upstream="master" revision="d3ed74763f8cba60f876949032ca6eadbc9cce25" />
+    <project name="xen-troops/xt-distro" path="xt-distro" upstream="master" revision="dc0ffd24f4785cc7cd8865faada61acbbbea2448" />
+</manifest>

--- a/prod_ces2019/prod-ces2019.xml
+++ b/prod_ces2019/prod-ces2019.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+    <remote name="github" fetch="git://github.com" />
+
+    <default remote="github" sync-j="10" sync-c="true" />
+
+    <project name="xen-troops/meta-xt-prod-ces2019" path="meta-xt-prod-ces2019" upstream="master" revision="master" />
+    <project name="xen-troops/meta-xt-images" path="meta-xt-images" upstream="master" revision="master" />
+    <project name="xen-troops/xt-distro" path="xt-distro" upstream="master" revision="master" />
+</manifest>

--- a/prod_devel/prod-devel.xml
+++ b/prod_devel/prod-devel.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+    <remote name="github" fetch="git://github.com" />
+
+    <default remote="github" sync-j="10" sync-c="true" />
+
+    <project name="iusyk/meta-xt-prod-devel" path="meta-xt-prod-devel" upstream="feature/test-prod-local-conf" revision="feature/test-prod-local-conf" />
+    <project name="xen-troops/meta-xt-images" path="meta-xt-images" upstream="master" revision="master" />
+    <project name="xen-troops/xt-distro" path="xt-distro" upstream="master" revision="master" />
+</manifest>

--- a/prod_devel_src/prod-devel-src.xml
+++ b/prod_devel_src/prod-devel-src.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+    <include name="prod-devel.xml"/>
+</manifest>

--- a/prod_gen3_test/prod-gen3-test.xml
+++ b/prod_gen3_test/prod-gen3-test.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+    <remote name="github" fetch="git://github.com" />
+
+    <default remote="github" sync-j="10" sync-c="true" />
+
+    <project name="xen-troops/meta-xt-prod-gen3-test" path="meta-xt-prod-gen3-test" upstream="master" revision="master" />
+    <project name="xen-troops/meta-xt-images" path="meta-xt-images" upstream="master" revision="master" />
+    <project name="xen-troops/xt-distro" path="xt-distro" upstream="master" revision="master" />
+</manifest>

--- a/prod_gen3_test_src/prod-gen3-test-src.xml
+++ b/prod_gen3_test_src/prod-gen3-test-src.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+    <include name="prod-gen3-test.xml"/>
+</manifest>

--- a/prod_gen3_test_v1/prod-gen3-test-v1.xml
+++ b/prod_gen3_test_v1/prod-gen3-test-v1.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+    <remote name="github" fetch="git://github.com" />
+
+    <default remote="github" sync-j="10" sync-c="true" />
+
+    <project name="xen-troops/meta-xt-prod-gen3-test" path="meta-xt-prod-gen3-test" upstream="gen3-test-v1" revision="922c7a5da9e9bd8df484356e2690e3879791435a" />
+    <project name="xen-troops/meta-xt-images" path="meta-xt-images" upstream="master" revision="e4e2c7bc76f0e11df12fb3e40d59725adb890dc2" />
+    <project name="xen-troops/xt-distro" path="xt-distro" upstream="master" revision="dc0ffd24f4785cc7cd8865faada61acbbbea2448" />
+</manifest>

--- a/prod_gen3_test_v2/prod-gen3-test-v2.xml
+++ b/prod_gen3_test_v2/prod-gen3-test-v2.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+    <remote name="github" fetch="git://github.com" />
+
+    <default remote="github" sync-j="10" sync-c="true" />
+
+    <project name="xen-troops/meta-xt-prod-gen3-test" path="meta-xt-prod-gen3-test" upstream="master" revision="refs/tags/v2.1" />
+    <project name="xen-troops/meta-xt-images" path="meta-xt-images" upstream="master" revision="refs/tags/v2.0.gen3-test" />
+    <project name="xen-troops/xt-distro" path="xt-distro" upstream="master" revision="refs/tags/v2.0.gen3-test" />
+</manifest>

--- a/prod_tu2019_demo/prod-tu2019-demo.xml
+++ b/prod_tu2019_demo/prod-tu2019-demo.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+    <remote name="github" fetch="git://github.com" />
+
+    <default remote="github" sync-j="10" sync-c="true" />
+
+    <project name="xen-troops/meta-xt-prod-tu2019-demo" path="meta-xt-prod-tu2019-demo" upstream="master" revision="f209e88bb64a7ea21bc2d924e1557238002225cd" />
+    <project name="xen-troops/meta-xt-images" path="meta-xt-images" upstream="master" revision="93bfbc76a38778f4df5851faee634c57e6f66487" />
+    <project name="xen-troops/xt-distro" path="xt-distro" upstream="master" revision="4c5546194353cca3008ed8d6309c4cc1c03403ff" />
+</manifest>


### PR DESCRIPTION
The manifests of the products are moved from meta-xt-images ro manifests

The idea is to collect all manifests in one repository.
There were 2 ways
1. Migrate from manifests to meta-xt-products 
2. Migrate from meta-xt-products to the manifests
The second option has been chosen because in the case  of option 1
the following needs to be done
- all products have to be modified to change the path to the manifest
- the configure step needs to be done for all products, to be sure that the 
correct manifests have been used

In the case of option 1 it is enough to move the manifests to the corresponded
directories and modify build-scripts/build_prod.py (one line of code)
To test, it is enough just to configure the layout using.

python ./build_prod.py --build-type dailybuild --machine [MACHINE NAME] --product [PRODUCT NAME] --branch [BRANCH OF THE MANIFEST] --with-local-conf --config [PRODUCT COMFIG FILE].cfg

Signed-off-by: Ihor Usyk <ihor_usyk@epam.com>