### PR TITLE
prod-aos: add linaro metalayer for domf

### DIFF
--- a/prod_aos/domf.xml
+++ b/prod_aos/domf.xml
@@ -10,6 +10,7 @@
 
     <project remote="yoctoproject" name="meta-virtualization" path="meta-virtualization" upstream="thud" revision="9e8c0c96b443828a255e7d6ca6291598347672ac" />
     <project remote="yoctoproject" name="poky" path="poky" upstream="thud" revision="e7f0177ef3b6e06b8bc1722fca0241fef08a1530" />
+    <project remote="linaro" name="openembedded/meta-linaro" path="meta-linaro" upstream="thud" revision="b30036d4ef7ce9fe746833fc54de6ac7b0e00638" />
     <project remote="openembedded" name="meta-openembedded" path="meta-openembedded" upstream="thud" revision="4cd3a39f22a2712bfa8fc657d09fe2c7765a4005" />
     <project remote="epam" name="epmd-aepr/meta-aos" path="meta-aos" upstream="master" revision="master" />
 </manifest>


### PR DESCRIPTION
meta-linaro is required to build optee recipes.

Signed-off-by: Oleksandr Grytsov <oleksandr_grytsov@epam.com>