### PR TITLE
prod-aos: add linaro metalayer for domf

### DIFF
--- a/prod_aos/domf.xml
+++ b/prod_aos/domf.xml
@@ -10,6 +10,7 @@
 
     <project remote="yoctoproject" name="meta-virtualization" path="meta-virtualization" upstream="dunfell" revision="92cd3467502bd27b98a76862ca6525ce425a8479" />
     <project remote="yoctoproject" name="poky" path="poky" upstream="dunfell" revision="dc38d5e494e53a7a03d5bd8d2429d0ef54cfbbbc" />
+    <project remote="linaro" name="openembedded/meta-linaro" path="meta-linaro" upstream="thud" revision="b30036d4ef7ce9fe746833fc54de6ac7b0e00638" />
     <project remote="openembedded" name="meta-openembedded" path="meta-openembedded" upstream="dunfell" revision="de37512b25c1f8c6bb6ab2b3782ac0fe01443483" />
     <project remote="epam" name="epmd-aepr/meta-aos" path="meta-aos" upstream="master" revision="master" />
 </manifest>


### PR DESCRIPTION
meta-linaro is required to build optee recipes.

Signed-off-by: Yevgen Abramov <Yevgen_Abramov@epam.com>