### PR TITLE
prod-aos: set meta-linaro to dunfell release for domf

### DIFF
--- a/prod_aos/domf.xml
+++ b/prod_aos/domf.xml
@@ -10,7 +10,7 @@
 
     <project remote="yoctoproject" name="meta-virtualization" path="meta-virtualization" upstream="dunfell" revision="92cd3467502bd27b98a76862ca6525ce425a8479" />
     <project remote="yoctoproject" name="poky" path="poky" upstream="dunfell" revision="dc38d5e494e53a7a03d5bd8d2429d0ef54cfbbbc" />
-    <project remote="linaro" name="openembedded/meta-linaro" path="meta-linaro" upstream="thud" revision="b30036d4ef7ce9fe746833fc54de6ac7b0e00638" />
+    <project remote="linaro" name="openembedded/meta-linaro" path="meta-linaro" upstream="dunfell" revision="10af9133aeb28b3487fd227c900c11b786505699" />
     <project remote="openembedded" name="meta-openembedded" path="meta-openembedded" upstream="dunfell" revision="de37512b25c1f8c6bb6ab2b3782ac0fe01443483" />
     <project remote="epam" name="epmd-aepr/meta-aos" path="meta-aos" upstream="master" revision="master" />
 </manifest>


### PR DESCRIPTION
domf used dunfell poky, meta-linaro should be from same release for
compatibility.

Signed-off-by: Oleksandr Grytsov <oleksandr_grytsov@epam.com>