### PR TITLE
Use correct tag v4.0.0 for meta-aos

### DIFF
--- a/prod_aos/domd.xml
+++ b/prod_aos/domd.xml
@@ -14,5 +14,5 @@
     <project remote="openembedded" name="meta-openembedded" path="meta-openembedded" upstream="thud" revision="4cd3a39f22a2712bfa8fc657d09fe2c7765a4005" />
     <project remote="linaro" name="openembedded/meta-linaro" path="meta-linaro" upstream="thud" revision="b30036d4ef7ce9fe746833fc54de6ac7b0e00638" />
     <project remote="yoctoproject" name="meta-selinux" path="meta-selinux" upstream="thud" revision="fb6192aa2c5df8e80c5e6d4fa5448d574332f68f" />
-    <project remote="epam" name="epmd-aepr/meta-aos" path="meta-aos" upstream="master" revision="refs/tags/4.0" />
+    <project remote="epam" name="epmd-aepr/meta-aos" path="meta-aos" upstream="master" revision="refs/tags/v4.0.0" />
 </manifest>

--- a/prod_aos/domf.xml
+++ b/prod_aos/domf.xml
@@ -12,5 +12,5 @@
     <project remote="yoctoproject" name="poky" path="poky" upstream="dunfell" revision="dc38d5e494e53a7a03d5bd8d2429d0ef54cfbbbc" />
     <project remote="linaro" name="openembedded/meta-linaro" path="meta-linaro" upstream="dunfell" revision="10af9133aeb28b3487fd227c900c11b786505699" />
     <project remote="openembedded" name="meta-openembedded" path="meta-openembedded" upstream="dunfell" revision="de37512b25c1f8c6bb6ab2b3782ac0fe01443483" />
-    <project remote="epam" name="epmd-aepr/meta-aos" path="meta-aos" upstream="master" revision="refs/tags/4.0" />
+    <project remote="epam" name="epmd-aepr/meta-aos" path="meta-aos" upstream="master" revision="refs/tags/v4.0.0" />
 </manifest>

--- a/prod_aos_minimal/aos.xml
+++ b/prod_aos_minimal/aos.xml
@@ -11,5 +11,5 @@
     <project remote="yoctoproject" name="meta-virtualization" path="meta-virtualization" upstream="dunfell" revision="dbd1a73fe7006dcc6d56a369c1de73340e03c939" />
     <project remote="openembedded" name="meta-openembedded" path="meta-openembedded" upstream="dunfell" revision="de37512b25c1f8c6bb6ab2b3782ac0fe01443483" />
     <project remote="github" name="xen-troops/meta-aos-minimal" path="meta-aos-minimal" upstream="master" revision="master" />
-    <project remote="epam" name="epmd-aepr/meta-aos" path="meta-aos" upstream="master" revision="refs/tags/4.0" />
+    <project remote="epam" name="epmd-aepr/meta-aos" path="meta-aos" upstream="master" revision="refs/tags/v4.0.0" />
 </manifest>


### PR DESCRIPTION
We have decided to switch to vx.x.x tag format.

Signed-off-by: Oleksandr Grytsov <oleksandr_grytsov@epam.com>