### PR TITLE
meta-clang: update revision.

### DIFF
--- a/prod_devel/domd.xml
+++ b/prod_devel/domd.xml
@@ -13,7 +13,7 @@
     <project remote="openembedded" name="meta-openembedded" path="meta-openembedded" upstream="thud" revision="4cd3a39f22a2712bfa8fc657d09fe2c7765a4005" />
     <project remote="linaro" name="openembedded/meta-linaro" path="meta-linaro" upstream="thud" revision="0a94decea3bd2504590d1637eadff9d502c19ee2" />
     <project remote="yoctoproject" name="meta-selinux" path="meta-selinux" upstream="thud" revision="fb6192aa2c5df8e80c5e6d4fa5448d574332f68f" />
-    <project name="kraj/meta-clang" path="meta-clang" upstream="thud" revision="7933fd19fe1df357df0532d3983c10d014e8d5f6" />
+    <project name="kraj/meta-clang" path="meta-clang" upstream="thud" revision="191bf60a6015fec46c101a4adbaf01b0fa2bcf7d" />
     <project name="CogentEmbedded/meta-rcar" path="meta-rcar" revision="e9bf7907fcf1f3013705de10a37b7561f6660e3c" upstream="thud-v3.21.0" />
 
 </manifest>

--- a/prod_devel/domu.xml
+++ b/prod_devel/domu.xml
@@ -12,5 +12,5 @@
     <project remote="openembedded" name="meta-openembedded" path="meta-openembedded" upstream="thud" revision="4cd3a39f22a2712bfa8fc657d09fe2c7765a4005" />
     <project remote="linaro" name="openembedded/meta-linaro" path="meta-linaro" upstream="thud" revision="0a94decea3bd2504590d1637eadff9d502c19ee2" />
     <project remote="yoctoproject" name="meta-selinux" path="meta-selinux" upstream="thud" revision="fb6192aa2c5df8e80c5e6d4fa5448d574332f68f" />
-    <project name="kraj/meta-clang" path="meta-clang" upstream="thud" revision="7933fd19fe1df357df0532d3983c10d014e8d5f6" />
+    <project name="kraj/meta-clang" path="meta-clang" upstream="thud" revision="191bf60a6015fec46c101a4adbaf01b0fa2bcf7d" />
 </manifest>


### PR DESCRIPTION
The old llvm repository github.com/llvm-project does not exist anymore.
The updated version of meta-clang has the correct MIRROR URI.

Signed-off-by: Ihor Usyk <ihor_usyk@epam.com>