### PR TITLE
prod-aos: update poky rev for domf

### DIFF
--- a/prod_aos/domf.xml
+++ b/prod_aos/domf.xml
@@ -9,7 +9,7 @@
     <default remote="github" sync-j="10" sync-c="true" />
 
     <project remote="yoctoproject" name="meta-virtualization" path="meta-virtualization" upstream="dunfell" revision="180241e0eee718fc52c7b6b25dbd1d845a8047c4" />
-    <project remote="yoctoproject" name="poky" path="poky" upstream="dunfell" revision="2a848e95074318f3a243df7b3f40513a13173a82" />
+    <project remote="yoctoproject" name="poky" path="poky" upstream="dunfell" revision="795339092f87672e4f68e4d3bc4cfd0e252d1831" />
     <project remote="linaro" name="openembedded/meta-linaro" path="meta-linaro" upstream="dunfell" revision="10af9133aeb28b3487fd227c900c11b786505699" />
     <project remote="openembedded" name="meta-openembedded" path="meta-openembedded" upstream="dunfell" revision="69f94af4d91215e7d4e225bab54bf3bcfee42f1c" />
     <project remote="epam" name="epmd-aepr/meta-aos" path="meta-aos" upstream="master" revision="refs/tags/v5.0.2" />


### PR DESCRIPTION
Current poky rev is too old compared to meta-openembedded. It causes build
error.

Signed-off-by: Oleksandr Grytsov <oleksandr_grytsov@epam.com>