### PR TITLE
meta-aos: change the url of the layer meta-aos.

### DIFF
--- a/prod_devel_src/domd.xml
+++ b/prod_devel_src/domd.xml
@@ -4,5 +4,5 @@
 
     <remote name="epam" fetch="ssh://git@gitpct.epam.com" />
     <project remote="epam" name="epmd-aepr/img-proprietary" path="proprietary" upstream="master" revision="ef1aa566d74a11c4d2ae9592474030a706b4cf39" />
-    <project remote="epam" name="epmd-aepr/meta-aos" path="meta-aos" upstream="master" revision="da4f35734fd6dc4053153aeaa7faa33dfc322f4a" />
+    <project remote="github" name="aoscloud/meta-aos" path="meta-aos" upstream="main" revision="4b0f4ea629db039af8cec8f9ea019bb4c9e6d0c7" />
 </manifest>


### PR DESCRIPTION
It has been done, because old one is not supported anymore.

Signed-off-by: Ihor Usyk <ihor_usyk@epam.com>