### PR TITLE
prod-devel: replace the gi protocol at https

### DIFF
--- a/prod_devel/dom0.xml
+++ b/prod_devel/dom0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-    <remote name="github" fetch="git://github.com" />
+    <remote name="github" fetch="https://github.com" />
     <remote name="yoctoproject" fetch="git://git.yoctoproject.org" />
     <remote name="openembedded" fetch="git://git.openembedded.org" />
 

--- a/prod_devel/domd.xml
+++ b/prod_devel/domd.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-    <remote name="github" fetch="git://github.com" />
+    <remote name="github" fetch="https://github.com" />
     <remote name="yoctoproject" fetch="git://git.yoctoproject.org" />
     <remote name="openembedded" fetch="git://git.openembedded.org" />
     <default remote="github" sync-j="10" sync-c="true" />

--- a/prod_devel/domf.xml
+++ b/prod_devel/domf.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-    <remote name="github" fetch="git://github.com" />
+    <remote name="github" fetch="https://github.com" />
     <remote name="yoctoproject" fetch="git://git.yoctoproject.org" />
     <remote name="openembedded" fetch="git://git.openembedded.org" />
     <remote name="linaro" fetch="git://git.linaro.org" />

--- a/prod_devel/domr.xml
+++ b/prod_devel/domr.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-    <remote name="github" fetch="git://github.com" />
+    <remote name="github" fetch="https://github.com" />
     <remote name="yoctoproject" fetch="git://git.yoctoproject.org" />
 
     <default remote="github" sync-j="10" sync-c="true" />

--- a/prod_devel/domu.xml
+++ b/prod_devel/domu.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-    <remote name="github" fetch="git://github.com" />
+    <remote name="github" fetch="https://github.com" />
     <remote name="yoctoproject" fetch="git://git.yoctoproject.org" />
     <remote name="openembedded" fetch="git://git.openembedded.org" />
 


### PR DESCRIPTION
git protocol is deprecated.

Signed-off-by: Ihor Usyk <ihor_usyk@epam.com>