### PR TITLE
prod-aos: remove meta-aos from domd, domf manifests

### DIFF
--- a/prod_aos/domd.xml
+++ b/prod_aos/domd.xml
@@ -13,5 +13,4 @@
     <project remote="openembedded" name="meta-openembedded" path="meta-openembedded" upstream="thud" revision="4cd3a39f22a2712bfa8fc657d09fe2c7765a4005" />
     <project remote="linaro" name="openembedded/meta-linaro" path="meta-linaro" upstream="thud" revision="b30036d4ef7ce9fe746833fc54de6ac7b0e00638" />
     <project remote="yoctoproject" name="meta-selinux" path="meta-selinux" upstream="thud" revision="fb6192aa2c5df8e80c5e6d4fa5448d574332f68f" />
-    <project remote="github" name="aoscloud/meta-aos" path="meta-aos" upstream="main" revision="refs/tags/v5.2.0" />
 </manifest>

--- a/prod_aos/domf.xml
+++ b/prod_aos/domf.xml
@@ -11,5 +11,4 @@
     <project remote="yoctoproject" name="poky" path="poky" upstream="dunfell" revision="795339092f87672e4f68e4d3bc4cfd0e252d1831" />
     <project remote="linaro" name="openembedded/meta-linaro" path="meta-linaro" upstream="dunfell" revision="10af9133aeb28b3487fd227c900c11b786505699" />
     <project remote="openembedded" name="meta-openembedded" path="meta-openembedded" upstream="dunfell" revision="69f94af4d91215e7d4e225bab54bf3bcfee42f1c" />
-    <project remote="github" name="aoscloud/meta-aos" path="meta-aos" upstream="main" revision="refs/tags/v5.2.0" />
 </manifest>


### PR DESCRIPTION
It will be used from upper yocto.

Signed-off-by: Oleksandr Grytsov <oleksandr_grytsov@epam.com>