### PR TITLE
prod-devel/meta-rcar: Use latest revision for v5.1.0

### DIFF
--- a/prod_devel/domd.xml
+++ b/prod_devel/domd.xml
@@ -17,5 +17,5 @@
 
     <project name="kraj/meta-clang" path="meta-clang" upstream="dunfell" revision="e63d6f9abba5348e2183089d6ef5ea384d7ae8d8" />
 
-    <project name="CogentEmbedded/meta-rcar" path="meta-rcar" revision="77fb5acc67c441d66a8ca3ab350e4d11622d86c1" upstream="v5.1.0" />
+    <project name="CogentEmbedded/meta-rcar" path="meta-rcar" revision="14c4ffd17d2bc148071c9f94540a2fbc06a08087" upstream="v5.1.0" />
 </manifest>


### PR DESCRIPTION
The KingFisher build is broken. It complains when parsing ctemplate recipe. Fortunately, the fix is already there:
https://github.com/CogentEmbedded/meta-rcar/commit/14c4ffd17d2bc148071c9f94540a2fbc06a08087

So update manifest to the latest revision for v5.1.0 which already includes required patch.

Signed-off-by: Oleksandr Tyshchenko <oleksandr_tyshchenko@epam.com>